### PR TITLE
fix local import for cinnamon 3.6

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -1,3 +1,4 @@
+
 const Applet    = imports.ui.applet;
 const St        = imports.gi.St;
 const Lang      = imports.lang;
@@ -6,16 +7,17 @@ const Settings  = imports.ui.settings;
 const GLib      = imports.gi.GLib;
 const Signals   = imports.signals;
 
+const EXTENSION_UUID = "timepp@zagortenay333";
+const AppletDir = imports.ui.appletManager.applets[EXTENSION_UUID];
+const Timer     = AppletDir.sections.timer;
+const Stopwatch = AppletDir.sections.stopwatch;
+const Pomodoro  = AppletDir.sections.pomodoro;
+const Alarms    = AppletDir.sections.alarms;
+const Todo      = AppletDir.sections.todo;
 
-const Timer     = imports.applet.sections.timer;
-const Stopwatch = imports.applet.sections.stopwatch;
-const Pomodoro  = imports.applet.sections.pomodoro;
-const Alarms    = imports.applet.sections.alarms;
-const Todo      = imports.applet.sections.todo;
 
-
-const PANEL_ITEM    = imports.applet.lib.panel_item;
-const ICON_FROM_URI = imports.applet.lib.icon_from_uri;
+const PANEL_ITEM    = AppletDir.lib.panel_item;
+const ICON_FROM_URI = AppletDir.lib.icon_from_uri;
 
 
 // l10n/translation

--- a/sections/alarms.js
+++ b/sections/alarms.js
@@ -15,11 +15,13 @@ const Signals     = imports.signals;
 
 
 // local imports
-const PANEL_ITEM    = imports.applet.lib.panel_item;
-const ICON_FROM_URI = imports.applet.lib.icon_from_uri;
-const MULTIL_ENTRY  = imports.applet.lib.multiline_entry;
-const NUM_PICKER    = imports.applet.lib.num_picker;
-const DAY_CHOOSER   = imports.applet.lib.day_chooser;
+const EXTENSION_UUID = "timepp@zagortenay333";
+const AppletDir = imports.ui.appletManager.applets[EXTENSION_UUID];
+const PANEL_ITEM    = AppletDir.lib.panel_item;
+const ICON_FROM_URI = AppletDir.lib.icon_from_uri;
+const MULTIL_ENTRY  = AppletDir.lib.multiline_entry;
+const NUM_PICKER    = AppletDir.lib.num_picker;
+const DAY_CHOOSER   = AppletDir.lib.day_chooser;
 
 
 const CACHE_FILE = GLib.get_home_dir() + '/.cache/timepp_alarms.json';

--- a/sections/pomodoro.js
+++ b/sections/pomodoro.js
@@ -12,11 +12,13 @@ const Mainloop    = imports.mainloop;
 const Signals     = imports.signals;
 const Lang        = imports.lang;
 
+const EXTENSION_UUID = "timepp@zagortenay333";
+const AppletDir = imports.ui.appletManager.applets[EXTENSION_UUID];
 
-const PANEL_ITEM    = imports.applet.lib.panel_item;
-const ICON_FROM_URI = imports.applet.lib.icon_from_uri;
-const NUM_PICKER    = imports.applet.lib.num_picker;
-const LPAD          = imports.applet.lib.leftpad;
+const PANEL_ITEM    = AppletDir.lib.panel_item;
+const ICON_FROM_URI = AppletDir.lib.icon_from_uri;
+const NUM_PICKER    = AppletDir.lib.num_picker;
+const LPAD          = AppletDir.lib.leftpad;
 
 
 const CACHE_FILE = GLib.get_home_dir() + '/.cache/timepp_pomodoro.json';

--- a/sections/stopwatch.js
+++ b/sections/stopwatch.js
@@ -12,9 +12,11 @@ const Signals   = imports.signals;
 
 
 // local imports
-const PANEL_ITEM    = imports.applet.lib.panel_item;
-const ICON_FROM_URI = imports.applet.lib.icon_from_uri;
-const LPAD          = imports.applet.lib.leftpad;
+const EXTENSION_UUID = "timepp@zagortenay333";
+AppletDir = imports.ui.appletManager.applets[EXTENSION_UUID];
+const PANEL_ITEM    = AppletDir.lib.panel_item;
+const ICON_FROM_URI = AppletDir.lib.icon_from_uri;
+const LPAD          = AppletDir.lib.leftpad;
 
 
 const CACHE_FILE = GLib.get_home_dir() + '/.cache/timepp_stopwatch.json';

--- a/sections/timer.js
+++ b/sections/timer.js
@@ -15,11 +15,13 @@ const Signals     = imports.signals;
 
 
 // local imports
-const PANEL_ITEM    = imports.applet.lib.panel_item;
-const ICON_FROM_URI = imports.applet.lib.icon_from_uri;
-const NUM_PICKER    = imports.applet.lib.num_picker;
-const MULTIL_ENTRY  = imports.applet.lib.multiline_entry;
-const LPAD          = imports.applet.lib.leftpad;
+const EXTENSION_UUID = "timepp@zagortenay333";
+AppletDir = imports.ui.appletManager.applets[EXTENSION_UUID];
+const PANEL_ITEM    = AppletDir.lib.panel_item;
+const ICON_FROM_URI = AppletDir.lib.icon_from_uri;
+const NUM_PICKER    = AppletDir.lib.num_picker;
+const MULTIL_ENTRY  = AppletDir.lib.multiline_entry;
+const LPAD          = AppletDir.lib.leftpad;
 
 
 

--- a/sections/todo.js
+++ b/sections/todo.js
@@ -15,14 +15,15 @@ const Lang        = imports.lang;
 const Signals     = imports.signals;
 const Mainloop    = imports.mainloop;
 
-
-const FUZZ           = imports.applet.lib.fuzzy_search;
-const LPAD           = imports.applet.lib.leftpad;
-const NUM_PICKER     = imports.applet.lib.num_picker;
-const PANEL_ITEM     = imports.applet.lib.panel_item;
-const MULTIL_ENTRY   = imports.applet.lib.multiline_entry;
-const ICON_FROM_URI  = imports.applet.lib.icon_from_uri;
-const SCROLL_TO_ITEM = imports.applet.lib.scroll_to_item;
+const EXTENSION_UUID = "timepp@zagortenay333";
+const AppletDir = imports.ui.appletManager.applets[EXTENSION_UUID];
+const FUZZ           = AppletDir.lib.fuzzy_search;
+const LPAD           = AppletDir.lib.leftpad;
+const NUM_PICKER     = AppletDir.lib.num_picker;
+const PANEL_ITEM     = AppletDir.lib.panel_item;
+const MULTIL_ENTRY   = AppletDir.lib.multiline_entry;
+const ICON_FROM_URI  = AppletDir.lib.icon_from_uri;
+const SCROLL_TO_ITEM = AppletDir.lib.scroll_to_item;
 
 
 const CACHE_FILE = GLib.get_home_dir() + '/.cache/timepp_todo.json';


### PR DESCRIPTION
This pull request fixed local imports for cinnamon 3.6.

The applet seems to work ok after the changes, I mainly tested the todo.txt part.

I could not test compatibility with other cinnamon versions, sorry.